### PR TITLE
Lastest s3cmd and change sed delimiter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM mongo:latest
 
 # backups to Amazon S3
-RUN apt-get update && apt-get install -y s3cmd && apt-get install -y cron && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y python-pip && apt-get install -y cron && rm -rf /var/lib/apt/lists/*
+RUN pip install s3cmd
 COPY s3cfg /root/.s3cfg
 
 # entrypoint

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,15 +8,15 @@ if [ -z "$S3_ACCESS_KEY" -o -z "$S3_SECRET_KEY" -o -z "$S3_URL" -o -z "$MONGO_UR
 fi
 
 # set s3 config
-sed -i "s/%%S3_ACCESS_KEY%%/$S3_ACCESS_KEY/g" /root/.s3cfg
-sed -i "s/%%S3_SECRET_KEY%%/$S3_SECRET_KEY/g" /root/.s3cfg
+sed -i "s|%%S3_ACCESS_KEY%%|$S3_ACCESS_KEY|g" /root/.s3cfg
+sed -i "s|%%S3_SECRET_KEY%%|$S3_SECRET_KEY|g" /root/.s3cfg
 
 # verify S3 config
 s3cmd ls "s3://$S3_URL" > /dev/null
 
 # set cron schedule TODO: check if the string is valid (five or six values separated by white space)
 [[ -z "$CRON_SCHEDULE" ]] && CRON_SCHEDULE='0 2 * * *' && \
-   echo "CRON_SCHEDULE set to default ('$CRON_SCHEDULE')"
+echo "CRON_SCHEDULE set to default ('$CRON_SCHEDULE')"
 
 # add a cron job
 echo "$CRON_SCHEDULE root rm -rf /tmp/dump && mongodump -h '$MONGO_URL' -u '$MONGO_USER' -p '$MONGO_PASSWORD' --out /tmp/dump/ --gzip >> /var/log/cron.log 2>&1 && s3cmd sync /tmp/dump s3://$S3_URL/ >> /var/log/cron.log 2>&1 && rm -rf /tmp/dump" >> /etc/crontab


### PR DESCRIPTION
- Latest s3cmd to support AWS v4 signature
- Change sed delimiter to | because S3_SECRET_KEY can have / or +